### PR TITLE
Add limited 'global statement' functionality (inefficient)

### DIFF
--- a/cms/db/__init__.py
+++ b/cms/db/__init__.py
@@ -110,7 +110,7 @@ from .drop import drop_db
 
 from .util import test_db_connection, get_contest_list, is_contest_id, \
     ask_for_contest, get_submissions, get_submission_results, \
-    get_datasets_to_judge, enumerate_files
+    get_datasets_to_judge, enumerate_files, get_global_statement
 
 
 configure_mappers()

--- a/cms/db/util.py
+++ b/cms/db/util.py
@@ -367,4 +367,8 @@ def get_global_statement(session, contest=None):
     if len({statement.digest for lang_code, statement in statements}) != 1:
         return None
 
+    # there must be more than one statement
+    if len(statements) < 2:
+        return None
+
     return next(statement for lang_code, statement in statements)

--- a/cms/db/util.py
+++ b/cms/db/util.py
@@ -337,3 +337,34 @@ def enumerate_files(
     digests = set(r[0] for r in session.execute(union(*queries)))
     digests.discard(Digest.TOMBSTONE)
     return digests
+
+
+def get_global_statement(session, contest=None):
+    """Return the global statement of the contest, if it exists.
+
+    If this contest has more than one task, each having a single statement,
+    and they're all the same, return that. Otherwise, return None."""
+    if contest is None:
+        return None
+
+    # just get everything!
+    # There's probably a more efficient way to do this though...
+
+    # each task must have exactly one statement
+    if not all(len(task.statements) == 1 for task in contest.tasks):
+        return None
+
+    statements = [(lang_code, statement)
+        for task in contest.tasks
+        for lang_code, statement in task.statements.items()
+    ]
+
+    # there must be exactly one language code
+    if len({lang_code for lang_code, statement in statements}) != 1:
+        return None
+
+    # there must be exactly one digest
+    if len({statement.digest for lang_code, statement in statements}) != 1:
+        return None
+
+    return next(statement for lang_code, statement in statements)

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -139,6 +139,7 @@ HANDLERS = [
     (r"/contest/([0-9]+)/tasks/add", AddContestTaskHandler),
 
     # Contest's global statement
+
     (r"/contest/([0-9]+)/globalstatement", ContestStatementHandler),
 
     # Contest's submissions / user tests

--- a/cms/server/admin/handlers/__init__.py
+++ b/cms/server/admin/handlers/__init__.py
@@ -44,6 +44,8 @@ from .contestquestion import \
     QuestionClaimHandler
 from .contestranking import \
     RankingHandler
+from .conteststatement import \
+    ContestStatementHandler
 from .contestsubmission import \
     ContestSubmissionsHandler, \
     ContestUserTestsHandler
@@ -135,6 +137,9 @@ HANDLERS = [
 
     (r"/contest/([0-9]+)/tasks", ContestTasksHandler),
     (r"/contest/([0-9]+)/tasks/add", AddContestTaskHandler),
+
+    # Contest's global statement
+    (r"/contest/([0-9]+)/globalstatement", ContestStatementHandler),
 
     # Contest's submissions / user tests
 

--- a/cms/server/admin/handlers/base.py
+++ b/cms/server/admin/handlers/base.py
@@ -43,7 +43,7 @@ from sqlalchemy.orm import subqueryload
 
 from cms import __version__, config
 from cms.db import Admin, Contest, Participation, Question, Submission, \
-    SubmissionResult, Task, Team, User, UserTest
+    SubmissionResult, Task, Team, User, UserTest, get_global_statement
 from cms.grading.scoretypes import get_score_type_class
 from cms.grading.tasktypes import get_task_type_class
 from cms.server import CommonRequestHandler, FileHandlerMixin
@@ -316,6 +316,7 @@ class BaseHandler(CommonRequestHandler):
         params["task_list"] = self.sql_session.query(Task).all()
         params["user_list"] = self.sql_session.query(User).all()
         params["team_list"] = self.sql_session.query(Team).all()
+        params["global_statement"] = get_global_statement(self.sql_session, self.contest)
         return params
 
     def write_error(self, status_code, **kwargs):

--- a/cms/server/admin/handlers/conteststatement.py
+++ b/cms/server/admin/handlers/conteststatement.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Contest Management System - http://cms-dev.github.io/
+# Copyright © 2023-2023 Kevin Atienza <kevin@noi.ph>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Statement-related handlers for AWS for a specific contest.
+
+"""
+
+try:
+    import tornado4.web as tornado_web
+except ImportError:
+    import tornado.web as tornado_web
+
+from cms.db import Contest, Session, Statement, Task
+from cmscommon.datetime import make_datetime
+from .base import BaseHandler, require_permission
+
+
+class ContestStatementHandler(BaseHandler):
+    """Add a global statement to a contest.
+
+    """
+    @require_permission(BaseHandler.PERMISSION_ALL)
+    def get(self, contest_id):
+        self.contest = self.safe_get_item(Contest, contest_id)
+        self.r_params = self.render_params()
+        self.render("add_global_statement.html", **self.r_params)
+
+    @require_permission(BaseHandler.PERMISSION_ALL)
+    def post(self, contest_id):
+        fallback_page = self.url("contest", contest_id, "globalstatement")
+
+        contest = self.safe_get_item(Contest, contest_id)
+
+        language = self.get_argument("language", "")
+        if len(language) == 0:
+            self.service.add_notification(
+                make_datetime(),
+                "No language code specified",
+                "The language code can be any string.")
+            self.redirect(fallback_page)
+            return
+        statement = self.request.files["statement"][0]
+        if not statement["filename"].endswith(".pdf"):
+            self.service.add_notification(
+                make_datetime(),
+                "Invalid contest statement",
+                "The contest statement must be a .pdf file.")
+            self.redirect(fallback_page)
+            return
+
+        contest_name = contest.name
+        self.sql_session.close()
+
+        try:
+            digest = self.service.file_cacher.put_file_content(
+                statement["body"],
+                "Global statement for contest %s (lang: %s)" % (
+                    contest_name,
+                    language))
+        except Exception as error:
+            self.service.add_notification(
+                make_datetime(),
+                "Contest global statement storage failed",
+                repr(error))
+            self.redirect(fallback_page)
+            return
+
+        self.sql_session = Session()
+
+        contest = self.safe_get_item(Contest, contest_id)
+        for task in contest.tasks:
+            self.sql_session\
+                    .query(Statement)\
+                    .filter(Statement.task_id == task.id)\
+                    .delete()
+            statement = Statement(language, digest, task=task)
+            self.sql_session.add(statement)
+
+        if self.try_commit():
+            self.redirect(self.url("contest", contest_id))
+        else:
+            self.redirect(fallback_page)

--- a/cms/server/admin/handlers/conteststatement.py
+++ b/cms/server/admin/handlers/conteststatement.py
@@ -8,7 +8,7 @@
 # Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
 # Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
 # Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
-# Copyright © 2023-2023 Kevin Atienza <kevin@noi.ph>
+# Copyright © 2023 Kevin Atienza <kevin@noi.ph>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/cms/server/admin/handlers/conteststatement.py
+++ b/cms/server/admin/handlers/conteststatement.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 
 # Contest Management System - http://cms-dev.github.io/
+# Copyright © 2010-2013 Giovanni Mascellani <mascellani@poisson.phc.unipi.it>
+# Copyright © 2010-2018 Stefano Maggiolo <s.maggiolo@gmail.com>
+# Copyright © 2010-2012 Matteo Boscariol <boscarim@hotmail.com>
+# Copyright © 2012-2018 Luca Wehrstedt <luca.wehrstedt@gmail.com>
+# Copyright © 2014 Artem Iglikov <artem.iglikov@gmail.com>
+# Copyright © 2014 Fabian Gundlach <320pointsguy@gmail.com>
+# Copyright © 2016 Myungwoo Chun <mc.tamaki@gmail.com>
 # Copyright © 2023-2023 Kevin Atienza <kevin@noi.ph>
 #
 # This program is free software: you can redistribute it and/or modify

--- a/cms/server/admin/templates/add_global_statement.html
+++ b/cms/server/admin/templates/add_global_statement.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block core %}
+<div class="core_title">
+  <h1><a href="{{ url("contest", contest.id) }}">{{ contest.name }}</a> - Upload global statement</h1>
+  <h1>WARNING: THIS WILL OVERWRITE ALL EXISTING STATEMENTS!!</h1>
+</div>
+<form enctype="multipart/form-data" action="{{ url("contest", contest.id, "globalstatement") }}" method="POST">
+  {{ xsrf_form_html|safe }}
+  Language code: <input type="text" name="language"/><br/>
+  <input type="file" name="statement"/><br/>
+  <input type="submit" value="Upload">
+  <input type="Reset" >
+</form>
+{% endblock core %}

--- a/cms/server/admin/templates/contest.html
+++ b/cms/server/admin/templates/contest.html
@@ -81,6 +81,22 @@
       </td>
       <td><input type="text" name="score_precision" value="{{ contest.score_precision }}"></td>
     </tr>
+    <tr>
+      <td>
+        <span class="info" title="The global statement of this contest."></span>
+        Global statement
+{% if admin.permission_all %}
+        [<a href="{{ url("contest", contest.id, "globalstatement") }}">set</a>]
+{% endif %}
+      </td>
+      <td>
+        {% if global_statement %}
+        <a href="{{ url("file", global_statement.digest, "statement.pdf") }}">Global statement</a>
+        {% else %}
+        No global statement.
+        {% endif %}
+      </td>
+    </tr>
 
     <tr><td colspan=2><h2>Logging in</h2></td></tr>
     <tr>

--- a/cms/server/contest/handlers/__init__.py
+++ b/cms/server/contest/handlers/__init__.py
@@ -26,6 +26,8 @@
 from .communication import \
     CommunicationHandler, \
     QuestionHandler
+from .contest import \
+    ContestStatementViewHandler
 from .main import \
     LoginHandler, \
     LogoutHandler, \
@@ -65,6 +67,8 @@ HANDLERS = [
     (r"/notifications", NotificationsHandler),
     (r"/printing", PrintingHandler),
     (r"/documentation", DocumentationHandler),
+
+    (r"/globalstatement", ContestStatementViewHandler),
 
     # Tasks
 

--- a/cms/server/contest/handlers/__init__.py
+++ b/cms/server/contest/handlers/__init__.py
@@ -68,6 +68,8 @@ HANDLERS = [
     (r"/printing", PrintingHandler),
     (r"/documentation", DocumentationHandler),
 
+    # Contest stuff
+
     (r"/globalstatement", ContestStatementViewHandler),
 
     # Tasks

--- a/cms/server/contest/handlers/task.py
+++ b/cms/server/contest/handlers/task.py
@@ -56,7 +56,12 @@ class TaskDescriptionHandler(ContestHandler):
         if task is None:
             raise tornado_web.HTTPError(404)
 
-        self.render("task_description.html", task=task, **self.r_params)
+        global_statement = self.get_global_statement()
+        self.render(
+                "task_description.html",
+                task=task,
+                global_statement=global_statement,
+                **self.r_params)
 
 
 class TaskStatementViewHandler(FileHandler):

--- a/cms/server/contest/templates/task_description.html
+++ b/cms/server/contest/templates/task_description.html
@@ -13,9 +13,17 @@
 </div>
 
 
-<h2>{% trans %}Statement{% endtrans %}</h2>
+<h2>{% if global_statement %}{% trans %}Statements{% endtrans %}{% else %}{% trans %}Statement{% endtrans %}{% endif %}</h2>
 
-{% if task.statements|length == 0 %}
+{% if global_statement %}
+<div class="row statement one_statement">
+    <div class="span9">
+    {% for lang_code in task.statements %}
+        <a href="{{ contest_url("globalstatement") }}" class="btn btn-large btn-success">{% trans %}Download contest statements (all tasks){% endtrans %}</a>
+    {% endfor %}
+    </div>
+</div>
+{% elif task.statements|length == 0 %}
 <div class="row statement no_statements">
     <div class="span9">
         {% trans %}no statement available{% endtrans %}


### PR DESCRIPTION
No changes to the DB were made here, so I had to use a hacky way of checking whether there is a global statement: Literally check that all tasks have exactly the same .pdf statements!

Luckily, CMS already caches files, so if two files are exactly the same, then they are stored as the same file object in the DB, and we can just compare digests instead of the full files.

Note that there's some inefficiency here since many requests will now call the `get_global_statements` function which fetches several objects from the DB just to compute whether there's a global statement.