### PR TITLE
Adjust the widths of the "name" columns in the ranking page

### DIFF
--- a/cmsranking/static/Scoreboard.js
+++ b/cmsranking/static/Scoreboard.js
@@ -188,9 +188,9 @@ var Scoreboard = new function () {
 <tr> \
     <th class=\"sel\"></th> \
     <th class=\"rank\">Rank</th> \
-    <th colspan=\"10\" class=\"f_name\">First Name</th> \
-    <th colspan=\"10\" class=\"l_name\">Last Name</th> \
-    <th class=\"team\">Team</th>";
+    <th colspan=\"16\" class=\"f_name\">First Name</th> \
+    <th colspan=\"7\" class=\"l_name\">Last Name</th> \
+    <th colspan=\"3\" class=\"team\">Team</th>";
 
         var contests = DataStore.contest_list;
         for (var i in contests) {
@@ -235,15 +235,15 @@ var Scoreboard = new function () {
 <tr class=\"user" + (user["selected"] > 0 ? " selected color" + user["selected"] : "") + "\" data-user=\"" + user["key"] + "\"> \
     <td class=\"sel\"></td> \
     <td class=\"rank\">" + user["rank"] + "</td> \
-    <td colspan=\"10\" class=\"f_name\">" + escapeHTML(user["f_name"]) + "</td> \
-    <td colspan=\"10\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td>";
+    <td colspan=\"16\" class=\"f_name\">" + escapeHTML(user["f_name"]) + "</td> \
+    <td colspan=\"7\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td>";
 
         if (user['team']) {
             result += " \
-    <td class=\"team\"><img src=\"" + Config.get_flag_url(user["team"]) + "\" title=\"" + DataStore.teams[user["team"]]["name"] + "\" /></td>";
+    <td colspan=\"3\" class=\"team\"><img src=\"" + Config.get_flag_url(user["team"]) + "\" title=\"" + DataStore.teams[user["team"]]["name"] + "\" /></td>";
         } else {
             result += " \
-    <td class=\"team\"></td>";
+    <td colspan=\"3\" class=\"team\"></td>";
         }
 
         var contests = DataStore.contest_list;


### PR DESCRIPTION
This is a quick hack; we could make this nicer later.

The thing I'm most unsure of is the effect of adding a colspan in the "team" column.

There's also a comment in the `Scoreboard.js` regarding the reason why they chose to set the widths this way. It may be ok for us to not follow that and style the scoreboard page however we want.